### PR TITLE
Set TXT/SPF records as TXT

### DIFF
--- a/123-reg/extract.js
+++ b/123-reg/extract.js
@@ -16,11 +16,7 @@ for (i = 1, len = rows.length - 2; i < len; i++) {
   destination = row.getElementsByClassName('dns_data')[0].title;
 
   if (type === 'TXT/SPF') {
-    if (destination.match(/^(v=spf1|spf2.0)/) !== null) {
-      type = 'SPF';
-    } else {
-      type = 'TXT';
-    }
+    type = 'TXT';
     destination = '"' + destination + '"';
   }
 


### PR DESCRIPTION
Thanks to @robwithhair for this recommendation in https://gist.github.com/biinari/faed94e70197e129b2dee57bdab20084#gistcomment-3052465

[RFC 7208 section 3.1](https://tools.ietf.org/html/rfc7208#section-3.1) deprecated use of the `SPF` record type in favour of just using `TXT`.