### PR TITLE
Set Default TTL to match records from 123-reg

### DIFF
--- a/123-reg/extract.js
+++ b/123-reg/extract.js
@@ -1,10 +1,14 @@
+// CONFIG BEGIN
+var defaultTTL = 14400;
+// CONFIG END
+
 var table = document.getElementsByClassName('advanced_dns')[0];
 var rows = table.getElementsByTagName('tr');
 var i, len, row;
 var hostname, type, priority, ttl, destination;
 var output = '';
 
-output += '$TTL 600\n'; // start with default TTL
+output += '$TTL ' + defaultTTL + '\n'; // start with default TTL
 
 // skip header and last two rows (add new entry, delete all entries)
 for (i = 1, len = rows.length - 2; i < len; i++) {
@@ -12,7 +16,7 @@ for (i = 1, len = rows.length - 2; i < len; i++) {
   hostname = row.getElementsByClassName('dns_hostname')[0].innerText;
   type = row.getElementsByClassName('dns_type')[0].innerText;
   priority = row.getElementsByClassName('dns_priority')[0].innerText;
-  ttl = row.getElementsByClassName('dns_ttl')[0].innerText;
+  ttl = row.getElementsByClassName('dns_ttl')[0].innerText || defaultTTL;
   destination = row.getElementsByClassName('dns_data')[0].title;
 
   if (type === 'TXT/SPF') {


### PR DESCRIPTION
SOA record in 123-reg sets minimum TTL to 14400 (seconds).
Currently, the TTL column in the advanced dns table is always blank so use
the default in each row output.

Thanks to @rorydonohue for this suggestion in https://gist.github.com/biinari/faed94e70197e129b2dee57bdab20084#gistcomment-3074649